### PR TITLE
Limit MSRs access

### DIFF
--- a/kernelland/ScaphandreDrv/Driver.c
+++ b/kernelland/ScaphandreDrv/Driver.c
@@ -54,9 +54,9 @@ NTSTATUS DispatchCreate(PDEVICE_OBJECT device, PIRP irp)
     /* Lookup CPU information */
     memset(manufacturer, 0, sizeof(manufacturer));
     __cpuid(cpu_regs, 0);
-    memcpy(manufacturer, &cpu_regs[1], sizeof(uint32_t));
-    memcpy(manufacturer + sizeof(uint32_t), &cpu_regs[3], sizeof(uint32_t));
-    memcpy(manufacturer + 2 * sizeof(uint32_t), &cpu_regs[2], sizeof(uint32_t));
+    memcpy(manufacturer, &cpu_regs[1], sizeof(unsigned __int32));
+    memcpy(manufacturer + sizeof(unsigned __int32), &cpu_regs[3], sizeof(unsigned __int32));
+    memcpy(manufacturer + 2 * sizeof(unsigned __int32), &cpu_regs[2], sizeof(unsigned __int32));
 
     if (strncmp(manufacturer, "GenuineIntel", sizeof(manufacturer) - 1) == 0)
         machine_type = E_MACHINE_INTEL;

--- a/kernelland/ScaphandreDrv/msr.c
+++ b/kernelland/ScaphandreDrv/msr.c
@@ -1,6 +1,6 @@
 #include "msr.h"
 
-int validate_msr_lookup(ULONGLONG msrRegister)
+int validate_msr_lookup(unsigned __int64 msrRegister)
 {
     int err;
 

--- a/kernelland/ScaphandreDrv/msr.h
+++ b/kernelland/ScaphandreDrv/msr.h
@@ -38,6 +38,6 @@ typedef enum {
 
 static e_machine_type machine_type;
 
-int validate_msr_lookup(ULONGLONG msrRegister);
+int validate_msr_lookup(unsigned __int64 msrRegister);
 
 #endif /* _MSR_H */


### PR DESCRIPTION
In order to fetch only MSRs that are useful for us and therefor not create a big backdoor allowing any programs to fetch any MSRs registers, this patch limits the MSRs access.

Open to discussion.