### PR TITLE
fix AMD CPU detection

### DIFF
--- a/ScaphandreDrv/Driver.c
+++ b/ScaphandreDrv/Driver.c
@@ -6,6 +6,8 @@
 #pragma alloc_text (INIT, DriverEntry)
 #endif
 
+e_machine_type machine_type;
+
 NTSTATUS DriverEntry(PDRIVER_OBJECT  DriverObject,
                      PUNICODE_STRING RegistryPath)
 {

--- a/ScaphandreDrv/msr.h
+++ b/ScaphandreDrv/msr.h
@@ -39,7 +39,7 @@ typedef enum {
 }e_machine_type;
 
 
-static e_machine_type machine_type;
+extern e_machine_type machine_type;
 static unsigned long max_processors;
 
 int validate_msr_lookup(unsigned __int64 msrRegister);


### PR DESCRIPTION
Firstly, thank you so much for building this. I'm working on a [Scaphandre-adjacent tool](https://github.com/wattwisegames/watt-wiser) focused on high-resolution energy measurement for desktop computers, and without this driver I'd be hard-pressed to get any CPU energy data on Windows. Thanks especially for the thorough docs and list of references in the README. That made it much easier for me to troubleshoot the problems I encountered.

Anyway, I discovered that the current driver code works great for Intel CPUs, but fails for AMD.

For some reason that I still don't understand, using a static variable for machine_type in msr.h doesn't work properly. The driver code correctly detects an AMD CPU and sets that value to AMD, but when it tries to invoke the function to check the MSR, that function's machine_type is Intel.

By shifting the static variable to the driver code and passing it explicitly as a parameter into the check function, I'm now able to get correct results on AMD systems.

This may not be the best fix, but without this change all attempts to read AMD MSRs are rejected because the logic is always checking the Intel MSR list.